### PR TITLE
Move the reservation and loging out of exec module

### DIFF
--- a/hdl/mem_space.sv
+++ b/hdl/mem_space.sv
@@ -48,10 +48,12 @@
  * data_sel_i           -- The number of bytes to r/w (1 -> 4'b0001, 2 -> 4'b0011, 3 -> 4'b0111 or 4 bytes -> 4'b1111).
  * data_we_i            -- 1'b1 to write data, 0 to read.
  * data_addr_i          -- The address from where data is read/written.
+ * data_addr_tag_i      -- The address tag.
  * data_data_i          -- The input data to write.
  * data_ack_o           -- The data transaction completes successfully on the posedge of this signal.
  * data_err_o           -- The data transaction completes with an error on the posedge of this signal.
  * data_data_o          -- The data that was read.
+ * data_data_tag_o      -- The data output tag
  * RAM wires            -- RAM wires.
  * flash_master_clk_i   -- The flash master clock.
  * flash_device_clk_i   -- Flash clock from the PLL.
@@ -89,10 +91,12 @@ module mem_space #(
     input logic [3:0] data_sel_i,
     input logic data_we_i,
     input logic [31:0] data_addr_i,
+    input logic [2:0] data_addr_tag_i,
     input logic [31:0] data_data_i,
     output logic data_ack_o,
     output logic data_err_o,
     output logic [31:0] data_data_o,
+    output logic data_data_tag_o,
 `ifdef BOARD_ULX3S
     input logic sdram_device_clk_i,
     // SDRAM wires
@@ -179,6 +183,7 @@ module mem_space #(
     logic sync_flash_ack_i, sync_flash_ack_i_pulse;
     DFF_META dff_meta_flash_ack (.reset(rst_i), .D(flash_ack_i), .clk(clk_i), .Q(sync_flash_ack_i),
                             .Q_pulse(sync_flash_ack_i_pulse));
+
     //==================================================================================================================
     // Instantiate the modules
     //==================================================================================================================
@@ -419,9 +424,10 @@ module mem_space #(
                     if (~ram_stb_o & ~ram_cyc_o & ~ram_ack_i) begin
 `ifdef D_MEM_SPACE
                         if (~data_we_i) begin
-                            $display($time, " MEM_SPACE: Reading RAM @[%h]", data_addr_i);
+                            $display($time, " MEM_SPACE: Reading RAM @[%h]; tag: %h", data_addr_i, data_addr_tag_i);
                         end else begin
-                            $display($time, " MEM_SPACE: Writing %h to RAM @[%h]", data_data_i, data_addr_i);
+                            $display($time, " MEM_SPACE: Writing %h to RAM @[%h]; tag: %h", data_data_i, data_addr_i,
+                                        data_addr_tag_i);
                         end
 `endif
                         start_ram_transaction_task(data_we_i, data_addr_i[23:0], data_sel_i, data_data_i);

--- a/hdl/risc_p.sv
+++ b/hdl/risc_p.sv
@@ -203,7 +203,8 @@ module risc_p (
     // Exec ports (we use the wire type to make it clear that this module is not using these signals)
     wire [31:0] data_addr_w, data_data_i_w, data_data_o_w;
     wire [3:0] data_sel_w;
-    wire data_we_w, data_stb_w, data_cyc_w, data_ack_w, data_err_w;
+    wire data_we_w, data_stb_w, data_cyc_w, data_ack_w, data_err_w, data_data_tag_w;
+    wire [2:0] data_addr_tag_w;
     // Event counters
     logic [31:0] incr_event_counters_o;
     // IO interrupt
@@ -243,6 +244,7 @@ module risc_p (
         .core_data_o        (core_data_i),
         // Wishbone interface for reading and writing data
         .data_addr_i        (data_addr_w),
+        .data_addr_tag_i    (data_addr_tag_w),
         .data_data_i        (data_data_i_w),
         .data_stb_i         (data_stb_w),
         .data_cyc_i         (data_cyc_w),
@@ -251,6 +253,7 @@ module risc_p (
         .data_ack_o         (data_ack_w),
         .data_err_o         (data_err_w),
         .data_data_o        (data_data_o_w),
+        .data_data_tag_o    (data_data_tag_w),
 `ifdef BOARD_ULX3S
         .sdram_device_clk_i (sdram_device_clk),
         // SDRAM wires
@@ -354,6 +357,7 @@ module risc_p (
         .trap_mtval_o       (exec_trap_mtval_i),
         // Read/write RAM/ROM/IO data for l(b/h/w) s(b/h/w) instructions
         .data_addr_o        (data_addr_w),
+        .data_addr_tag_o    (data_addr_tag_w),
         .data_data_o        (data_data_i_w),
         .data_stb_o         (data_stb_w),
         .data_cyc_o         (data_cyc_w),
@@ -361,7 +365,8 @@ module risc_p (
         .data_we_o          (data_we_w),
         .data_ack_i         (data_ack_w),
         .data_err_i         (data_err_w),
-        .data_data_i        (data_data_o_w));
+        .data_data_i        (data_data_o_w),
+        .data_tag_i         (data_data_tag_w));
 
     //==================================================================================================================
     // Definitions

--- a/hdl/risc_s.sv
+++ b/hdl/risc_s.sv
@@ -203,7 +203,8 @@ module risc_s (
     // Exec ports (we use the wire type to make it clear that this module is not using these signals)
     wire [31:0] data_addr_w, data_data_i_w, data_data_o_w;
     wire [3:0] data_sel_w;
-    wire data_we_w, data_stb_w, data_cyc_w, data_ack_w, data_err_w;
+    wire data_we_w, data_stb_w, data_cyc_w, data_ack_w, data_err_w, data_data_tag_w;
+    wire [2:0] data_addr_tag_w;
     // Event counters
     logic [31:0] incr_event_counters_o;
     // IO interrupt
@@ -244,6 +245,7 @@ module risc_s (
         .core_data_o        (core_data_i),
         // Wishbone interface for reading and writing data
         .data_addr_i        (data_addr_w),
+        .data_addr_tag_i    (data_addr_tag_w),
         .data_data_i        (data_data_i_w),
         .data_stb_i         (data_stb_w),
         .data_cyc_i         (data_cyc_w),
@@ -252,6 +254,7 @@ module risc_s (
         .data_ack_o         (data_ack_w),
         .data_err_o         (data_err_w),
         .data_data_o        (data_data_o_w),
+        .data_data_tag_o    (data_data_tag_w),
 `ifdef BOARD_ULX3S
         .sdram_device_clk_i (sdram_device_clk),
         // SDRAM wires
@@ -355,6 +358,7 @@ module risc_s (
         .trap_mtval_o       (exec_trap_mtval_i),
         // Read/write RAM/ROM/IO data for l(b/h/w) s(b/h/w) instructions
         .data_addr_o        (data_addr_w),
+        .data_addr_tag_o    (data_addr_tag_w),
         .data_data_o        (data_data_i_w),
         .data_stb_o         (data_stb_w),
         .data_cyc_o         (data_cyc_w),
@@ -362,7 +366,8 @@ module risc_s (
         .data_we_o          (data_we_w),
         .data_ack_i         (data_ack_w),
         .data_err_i         (data_err_w),
-        .data_data_i        (data_data_o_w));
+        .data_data_i        (data_data_o_w),
+        .data_tag_i         (data_data_tag_w));
 
     //==================================================================================================================
     // Definitions

--- a/hdl/tags.svh
+++ b/hdl/tags.svh
@@ -1,0 +1,37 @@
+/***********************************************************************************************************************
+ * Copyright (c) 2024 Virgil Dobjanschi dobjanschivirgil@gmail.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+ * OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ **********************************************************************************************************************/
+
+/***********************************************************************************************************************
+ * This module defines tags for the Wishbone interface.
+ **********************************************************************************************************************/
+`timescale 1ns/1ns
+`default_nettype none
+
+/*
+ * Bit 0 define the locking/unlocking register reservation/invalidate reservation operation.
+ */
+`define ADDR_TAG_LOCK           1'b1
+`define ADDR_TAG_UNLOCK         1'b0
+
+/*
+ * Bit 1 and 2 of the address tag define the type of locking/reservation to be used in a R/W operation.
+ */
+`define ADDR_TAG_MODE_LRSC      2'b01
+`define ADDR_TAG_MODE_AMO       2'b10
+
+// No locking
+`define ADDR_TAG_MODE_NONE      3'b000


### PR DESCRIPTION
The lr/sc reservation was moved out of the exec module. The amo* instructions locking is enabled.

Address tag bits are used to implement the registration/invalidation of the register set for lr/sc instructions and for amo* instructions memory locking.

The actual reservation and locking is to be implemented.